### PR TITLE
Validate JSONP callback in webtc getword.php + query.php (reflected-XSS)

### DIFF
--- a/vn/gra-dev/web/webtc/getword.php
+++ b/vn/gra-dev/web/webtc/getword.php
@@ -13,8 +13,15 @@ function getwordCall() {
   $temp = new GetwordClass();
   $table1 = $temp->table1;
   if (isset($_GET['callback'])) {
+ $callback = $_GET['callback'];
+   if (!preg_match('/^[A-Za-z_$][A-Za-z0-9_$.]{0,127}$/',$callback)) {
+    header('content-type: text/plain; charset=utf-8');
+    http_response_code(400);
+    echo "invalid callback";
+    return;
+   }
    $json = json_encode($table1);
-   echo "{$_GET['callback']}($json)";
+   echo "{$callback}($json)";
   }else {
    echo $table1;
   }

--- a/vn/gra-dev/web/webtc2/query.php
+++ b/vn/gra-dev/web/webtc2/query.php
@@ -33,7 +33,14 @@ $lastLnum = $model->lastLnum;
 $ans = construct_outputarr($getParms,$model,$dictcode,$getParms->filter);
 $json = json_encode($ans);
 if(isset($_GET['callback'])) {
- echo "{$_GET['callback']}($json)";
+ $callback = $_GET['callback'];
+ if (!preg_match('/^[A-Za-z_$][A-Za-z0-9_$.]{0,127}$/',$callback)) {
+  header('content-type: text/plain; charset=utf-8');
+  http_response_code(400);
+  echo "invalid callback";
+  exit;
+ }
+ echo "{$callback}($json)";
 }else {
  echo $json;
 }


### PR DESCRIPTION
## What

Validates the JSONP `callback` parameter in `vn/gra-dev/web/webtc/getword.php` and `vn/gra-dev/web/webtc2/query.php` before reflecting it.

## Why

Both files echoed `$_GET['callback']` straight into the response (`echo "{$_GET['callback']}($json)"`) with no validation — a reflected-XSS / JSONP-injection vector. This applies the same JS-identifier guard already used upstream in [csl-websanlexicon](https://github.com/sanskrit-lexicon/csl-websanlexicon) (getword.php PR #63 / #27, query.php PR #67). These are generated copies, so a server-side regeneration from the fixed templates would also carry the fix; this closes the gap now.

🤖 Generated with [Claude Code](https://claude.com/claude-code)