### PR TITLE
Validate JSONP callback in gra-dev getword.php/query.php (reflected-XSS)

### DIFF
--- a/vn/gra-dev/web/webtc/getword.php
+++ b/vn/gra-dev/web/webtc/getword.php
@@ -13,8 +13,18 @@ function getwordCall() {
   $temp = new GetwordClass();
   $table1 = $temp->table1;
   if (isset($_GET['callback'])) {
+   $callback = $_GET['callback'];
+   // Only allow a safe JSONP callback identifier. Echoing the raw callback
+   // is a reflected-XSS / JSONP-injection vector, so reject anything else.
+   // Mirrors the guard in csl-websanlexicon webtc/getword.php (issue #27, PR #63).
+   if (!preg_match('/^[A-Za-z_$][A-Za-z0-9_$.]{0,127}$/',$callback)) {
+    header('content-type: text/plain; charset=utf-8');
+    http_response_code(400);
+    echo "invalid callback";
+    return;
+   }
    $json = json_encode($table1);
-   echo "{$_GET['callback']}($json)";
+   echo "{$callback}($json)";
   }else {
    echo $table1;
   }

--- a/vn/gra-dev/web/webtc2/query.php
+++ b/vn/gra-dev/web/webtc2/query.php
@@ -33,7 +33,17 @@ $lastLnum = $model->lastLnum;
 $ans = construct_outputarr($getParms,$model,$dictcode,$getParms->filter);
 $json = json_encode($ans);
 if(isset($_GET['callback'])) {
- echo "{$_GET['callback']}($json)";
+ $callback = $_GET['callback'];
+ // $callback is reflected into the JSONP response; an unrestricted value is a
+ // reflected-XSS / JSONP-injection vector, so reject anything that is not a
+ // plain JS identifier (mirrors csl-websanlexicon webtc2/query.php, #27/#67).
+ if (!preg_match('/^[A-Za-z_$][A-Za-z0-9_$.]{0,127}$/',$callback)) {
+  header('content-type: text/plain; charset=utf-8');
+  http_response_code(400);
+  echo "invalid callback";
+  exit;
+ }
+ echo "{$callback}($json)";
 }else {
  echo $json;
 }


### PR DESCRIPTION
## Summary

Second-pass security cleanup. The two `gra-dev` web display copies still echoed `$_GET['callback']` **unvalidated** into their JSONP responses — a reflected-XSS / JSONP-injection sink:

- [`vn/gra-dev/web/webtc/getword.php`](https://github.com/sanskrit-lexicon/GRA/blob/security/jsonp-callback-xss-gradev/vn/gra-dev/web/webtc/getword.php) (was line 17): `echo "{$_GET['callback']}($json)";`
- [`vn/gra-dev/web/webtc2/query.php`](https://github.com/sanskrit-lexicon/GRA/blob/security/jsonp-callback-xss-gradev/vn/gra-dev/web/webtc2/query.php) (was line 36): `echo "{$_GET['callback']}($json)";`

These are older **generated display copies** that predate the upstream fix in [`csl-websanlexicon`](https://github.com/sanskrit-lexicon/csl-websanlexicon). `gra-dev` is a dev / local-install build (see [`vn/gra-dev/web/readme.txt`](https://github.com/sanskrit-lexicon/GRA/blob/master/vn/gra-dev/web/readme.txt) — it is installed and served under XAMPP per those instructions), so the sink is reachable wherever someone follows that readme.

## Fix

Apply the **same callback-identifier guard** already merged upstream, rejecting any non-identifier value with HTTP 400:

```php
if (!preg_match('/^[A-Za-z_$][A-Za-z0-9_$.]{0,127}$/',$callback)) {
  header('content-type: text/plain; charset=utf-8');
  http_response_code(400);
  echo "invalid callback";  // return; in getword (inside fn), exit; in query
}
echo "{$callback}($json)";
```

This mirrors `csl-websanlexicon` [`v02/makotemplates/web/webtc/getword.php`](https://github.com/sanskrit-lexicon/csl-websanlexicon/blob/master/v02/makotemplates/web/webtc/getword.php) and [`webtc2/query.php`](https://github.com/sanskrit-lexicon/csl-websanlexicon/blob/master/v02/makotemplates/web/webtc2/query.php), i.e. issue [csl-websanlexicon#27](https://github.com/sanskrit-lexicon/csl-websanlexicon/issues/27) / PR [#63](https://github.com/sanskrit-lexicon/csl-websanlexicon/pull/63) (getword) and PR [#67](https://github.com/sanskrit-lexicon/csl-websanlexicon/pull/67) (query). The canonical upstream templates remain the source of truth; this patches the checked-in `gra-dev` copies so they are safe today regardless of server-side regeneration timing.

## Verification

- `php -l` clean on both files (PHP 8.2).
- Guard accepts valid JSONP identifiers (`jQuery21405`, `ns.cb_1`) and rejects every attack/edge payload (`alert(1)`, `"];alert(1)//`, `<script>`, leading-digit, empty, 200-char overflow) with 400.

🤖 Generated with [Claude Code](https://claude.com/claude-code)