### PR TITLE
fix: correct Grassmann spelling (one m) in CITATION + README

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -1,6 +1,6 @@
 cff-version: 1.2.0
 type: dataset
-title: Grassman Wörterbuch zum Rig Veda
+title: Grassmann Wörterbuch zum Rig Veda
 message: If you use this dataset, please cite both the digital edition and the printed source it digitises.
 license: CC-BY-SA-4.0
 repository-code: https://github.com/sanskrit-lexicon/GRA
@@ -18,7 +18,7 @@ authors:
     website: https://www.sanskrit-lexicon.uni-koeln.de/
 preferred-citation:
   type: book
-  title: Grassman Wörterbuch zum Rig Veda
+  title: Grassmann Wörterbuch zum Rig Veda
   year: 1873
   authors:
     - family-names: "Grassmann"


### PR DESCRIPTION
## What

Correct the misspelling **"Grassman"** (single *n*) → **"Grassmann"** in `CITATION.cff`.

Hermann **Grassmann** authored the *Wörterbuch zum Rig-Veda* (Leipzig, 1873). His surname ends in a double *n*. Two `title:` fields carried the single-*n* misspelling:

- `title:` (top-level dataset title)
- `preferred-citation.title:`

The already-correct `family-names: "Grassmann"` entry was left untouched.

## Notes

- `README.md` was grepped for the single-*n* misspelling — none found, so no README change was needed.
- Documentation-only / metadata-only change; no data or tooling affected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
